### PR TITLE
Create `DocumentSymbolProvider`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // Library
 import * as vscode from 'vscode';
 import { DocumentSemanticTokensProvider } from './highlight';
+import { DocumentSymbolProvider } from './symbols';
 
 /** This method is called when your extension is activated */
 export function activate(context: vscode.ExtensionContext) {
@@ -9,6 +10,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register the semantic tokens provider for the CSV language to provide syntax highlighting
 	DocumentSemanticTokensProvider.initialize(context);
+
+	// Register the document symbol provider for the CSV language to provide symbol information
+	DocumentSymbolProvider.initialize(context);
 
 }
 

--- a/src/library/Parser.ts
+++ b/src/library/Parser.ts
@@ -92,6 +92,11 @@ export abstract class _Parser<Cell extends ViableCellTypes = string> {
         });
     }
 
+    /** @returns the header corresponding to the given column number */
+    getHeader(column: number): Cell | undefined {
+        return this.headers.at(column);
+    }
+
     /**
      * Parses a line into an array of cells
      * @param line The line to parse into an array of cells

--- a/src/library/VSCSV.ts
+++ b/src/library/VSCSV.ts
@@ -1,4 +1,5 @@
 // Library
+import * as vscode from "vscode";
 import { _Parser } from "./Parser";
 
 // -----
@@ -22,6 +23,8 @@ export class VSCSV extends _Parser<Cell> {
             line: lineNumber,
             column: columnNumber,
             columnEnd: columnNumber + value.length,
+            length: value.length,
+            range: new vscode.Range(lineNumber, columnNumber, lineNumber, columnNumber + value.length),
             toString: () => value
         };
     }
@@ -44,6 +47,10 @@ type Cell = {
     column: number;
     /** The column number of the cell's end */
     columnEnd: number;
+    /** The length of the cell */
+    length: number;
+    /** The range of the cell */
+    range: vscode.Range;
     /** Converts the cell into a string */
     toString: () => string;
 };

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -65,33 +65,31 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         const csv = this.parser.parse(document.getText());
 
         // Iterate over the rows in the CSV document...
-        for (const r in csv.data) {
-            const row = csv.data[r];
-            if (!row.length) { continue; } // Exit if the row is empty
+        csv.data.forEach((row, r) => {
+            if (!row.length) { return; } // Exit if the row is empty
 
             // Create a symbol for the row
-            const rowSymbol = this.createRowSymbol(document, +r);
+            const rowSymbol = this.createRowSymbol(document, r);
 
             // Iterate over the cells in the row...
-            for (const c in row) {
-                const cell = row[c];
-                if (!cell.value) { continue; } // Exit if the cell is empty
+            row.forEach((cell, c) => {
+                if (!cell.value) { return; } // Exit if the cell is empty
 
                 // Create a symbol for the cell and add it to the row symbol
                 const cellSymbol = this.createCellSymbol(
                     cell.value,
                     cell.range,
-                    +r,
-                    +c,
-                    csv.getHeader(+c)?.value
+                    r,
+                    c,
+                    csv.getHeader(c)?.value
                 );
 
                 rowSymbol.children.push(cellSymbol);
-            }
+            });
 
             // Add the row symbol to the document symbol
             documentSymbol.children.push(rowSymbol);
-        }
+        });
 
         // Return the symbols
         return [documentSymbol];

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -45,13 +45,21 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
 
-        // Initialize the symbols array
-        const symbols: vscode.DocumentSymbol = new vscode.DocumentSymbol(
+        /** Range of the entire document. Used in the {@linkcode documentSymbol} */
+        const entireRange = new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE);
+
+        /**
+         * This {@link vscode.DocumentSymbol | symbol} will be the parent of all other symbols in the document
+         * providing a range that spans the entire document. This allows the
+         * first row (header row) to remain visible when scrolling through the document.
+         * @see {@link vscode.DocumentSymbol}
+         */
+        const documentSymbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
             document.fileName,
             document.languageId,
             vscode.SymbolKind.File,
-            new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE),
-            new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE),
+            entireRange,
+            entireRange,
         );
 
         // Parse the CSV document

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,5 +1,6 @@
 // Library
 import * as vscode from 'vscode';
+import { VSCSV } from './library';
 
 // -------
 // SYMBOLS
@@ -36,11 +37,57 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
     // INSTANCE
     // --------
 
+    private parser = new VSCSV();
+
     public provideDocumentSymbols(
         document: vscode.TextDocument,
         token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
-        return [];
+
+        // Initialize the symbols array
+        const symbols: vscode.DocumentSymbol[] = [];
+
+        // Parse the CSV document
+        const csv = this.parser.parse(document.getText());
+
+        // Iterate over the rows in the CSV document...
+        for (const r in csv.data) {
+            const row = csv.data[r];
+            if (!row.length) { continue; } // Exit if the row is empty
+
+            // Create a symbol for the row and add it to the symbols array
+            const range = new vscode.Range(+r, 0, +r, Number.MAX_VALUE);
+            const rowSymbols: vscode.DocumentSymbol = new vscode.DocumentSymbol(
+                r,
+                document.getText(range),
+                vscode.SymbolKind.Array,
+                range,
+                range,
+            );
+
+            // Iterate over the cells in the row...
+            for (const c in row) {
+                const cell = row[c];
+                if (!cell.value) { continue; }
+
+                // Create a symbol for the cell and add it to the row symbol
+                const range = new vscode.Range(cell.line, cell.column, cell.line, cell.columnEnd);
+                const symbol = new vscode.DocumentSymbol(
+                    r + ":" + c + " " + csv.headers[c].value + ": " + cell.value,
+                    csv.headers[c].value || cell.value,
+                    vscode.SymbolKind.Field,
+                    range,
+                    range,
+                );
+                rowSymbols.children.push(symbol);
+            }
+
+            // Add the row symbol to the symbols array
+            symbols.push(rowSymbols);
+        }
+
+        // Return the symbols array
+        return symbols;
     }
 
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -70,14 +70,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             if (!row.length) { continue; } // Exit if the row is empty
 
             // Create a symbol for the row
-            const range = new vscode.Range(+r, 0, +r, Number.MAX_VALUE); // Range of the entire row
-            const rowSymbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
-                r,
-                document.getText(range),
-                vscode.SymbolKind.Array,
-                range,
-                range,
-            );
+            const rowSymbol = this.createRowSymbol(document, +r);
 
             // Iterate over the cells in the row...
             for (const c in row) {
@@ -118,6 +111,23 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             entireRange,
         );
         return documentSymbol;
+    }
+
+    /**
+     * Creates a symbol for a row in the CSV document.
+     * @param document The {@link vscode.TextDocument | document} to create the symbol for
+     * @param index The index of the row in the CSV document
+     */
+    private createRowSymbol(document: vscode.TextDocument, index: number): vscode.DocumentSymbol {
+        const range = new vscode.Range(index, 0, index, Number.MAX_VALUE); // Range of the entire row
+        const rowSymbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
+            index.toString(),
+            document.getText(range),
+            vscode.SymbolKind.Array,
+            range,
+            range,
+        );
+        return rowSymbol;
     }
 
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -11,7 +11,8 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
     // STATIC
     // ------
 
-    /** The disposable used to unregister this provider */
+    /** The document selector for the CSV language */
+    private static selector: vscode.DocumentSelector = { language: 'csv' };
     private static disposable: vscode.Disposable;
 
     /**

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,46 @@
+// Library
+import * as vscode from 'vscode';
+
+// -------
+// SYMBOLS
+// -------
+
+export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+
+    // STATIC
+    // ------
+
+    /** The disposable used to unregister this provider */
+    private static disposable: vscode.Disposable;
+
+    /**
+     * Initialize the document symbol provider for the CSV language to provide symbol information.
+     * @param context The vscode extension context (see {@linkcode vscode.ExtensionContext})
+     */
+    public static initialize(context: vscode.ExtensionContext) {
+        this.dispose(); // Dispose of any existing provider
+        // Register the document symbol provider for the CSV language to provide symbol information
+        this.disposable = vscode.languages.registerDocumentSymbolProvider(
+            { language: 'csv' },
+            new DocumentSymbolProvider()
+        );
+        // Register the disposable to dispose of the provider when the extension is deactivated
+        context.subscriptions.push(this.disposable);
+    }
+
+    /** Dispose of the document symbol provider */
+    public static dispose() {
+        this.disposable?.dispose();
+    }
+
+    // INSTANCE
+    // --------
+
+    public provideDocumentSymbols(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+        return [];
+    }
+
+}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -53,22 +53,13 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
 
-        /** Range of the entire document. Used in the {@linkcode documentSymbol} */
-        const entireRange = new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE);
-
         /**
          * This {@link vscode.DocumentSymbol | symbol} will be the parent of all other symbols in the document
          * providing a range that spans the entire document. This allows the
          * first row (header row) to remain visible when scrolling through the document.
          * @see {@link vscode.DocumentSymbol}
          */
-        const documentSymbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
-            document.fileName,
-            document.languageId,
-            vscode.SymbolKind.File,
-            entireRange,
-            entireRange,
-        );
+        const documentSymbol = this.createDocumentSymbol(document);
 
         // Parse the CSV document
         const csv = this.parser.parse(document.getText());
@@ -111,6 +102,22 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 
         // Return the symbols
         return [documentSymbol];
+    }
+
+    /** Creates a symbol for the {@link vscode.TextDocument | document} */
+    private createDocumentSymbol(document: vscode.TextDocument): vscode.DocumentSymbol {
+        /** Range of the entire document. Used in the {@linkcode documentSymbol} */
+        const entireRange = new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE);
+
+        // Create a symbol for the document and return it        
+        const documentSymbol: vscode.DocumentSymbol = new vscode.DocumentSymbol(
+            document.fileName,
+            document.languageId,
+            vscode.SymbolKind.File,
+            entireRange,
+            entireRange,
+        );
+        return documentSymbol;
     }
 
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -78,14 +78,14 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
                 if (!cell.value) { continue; } // Exit if the cell is empty
 
                 // Create a symbol for the cell and add it to the row symbol
-                const range = new vscode.Range(cell.line, cell.column, cell.line, cell.columnEnd);
-                const cellSymbol = new vscode.DocumentSymbol(
-                    r + ":" + c + " " + csv.headers[c].value + ": " + cell.value,
-                    csv.headers[c].value || cell.value,
-                    vscode.SymbolKind.String,
-                    range,
-                    range,
+                const cellSymbol = this.createCellSymbol(
+                    cell.value,
+                    cell.range,
+                    +r,
+                    +c,
+                    csv.getHeader(+c)?.value
                 );
+
                 rowSymbol.children.push(cellSymbol);
             }
 
@@ -128,6 +128,26 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             range,
         );
         return rowSymbol;
+    }
+
+    /**
+     * Creates a symbol for a cell in the CSV document.
+     * @param value The value of the cell
+     * @param range The range of the cell (see {@linkcode vscode.Range})
+     * @param row The row index of the cell
+     * @param column The column index of the cell
+     * @param header The header of the column the cell is in (if any)
+     */
+    private createCellSymbol(value: string, range: vscode.Range, row: number, column: number, header: string = ""): vscode.DocumentSymbol {
+        const nameInfo = header ? value : header + ": " + value;
+        const cellSymbol = new vscode.DocumentSymbol(
+            row + ":" + column + " " + nameInfo,
+            header || value,
+            vscode.SymbolKind.String,
+            range,
+            range,
+        );
+        return cellSymbol;
     }
 
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -45,7 +45,13 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
     ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
 
         // Initialize the symbols array
-        const symbols: vscode.DocumentSymbol[] = [];
+        const symbols: vscode.DocumentSymbol = new vscode.DocumentSymbol(
+            document.fileName,
+            document.languageId,
+            vscode.SymbolKind.File,
+            new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE),
+            new vscode.Range(0, 0, document.lineCount, Number.MAX_VALUE),
+        );
 
         // Parse the CSV document
         const csv = this.parser.parse(document.getText());
@@ -75,7 +81,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
                 const symbol = new vscode.DocumentSymbol(
                     r + ":" + c + " " + csv.headers[c].value + ": " + cell.value,
                     csv.headers[c].value || cell.value,
-                    vscode.SymbolKind.Field,
+                    vscode.SymbolKind.String,
                     range,
                     range,
                 );
@@ -83,11 +89,11 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             }
 
             // Add the row symbol to the symbols array
-            symbols.push(rowSymbols);
+            symbols.children.push(rowSymbols);
         }
 
         // Return the symbols array
-        return symbols;
+        return [symbols];
     }
 
 }

--- a/src/test/library/Parser.test.ts
+++ b/src/test/library/Parser.test.ts
@@ -311,6 +311,20 @@ suite('Parser', () => {
                 assert.deepStrictEqual(actual, expected);
             });
 
+            test('should return the correct header', () => {
+                const input = 'a,b,c\n1,2,3\nx,y,z';
+                const expected = 'b';
+                const actual = new Parser().parse(input).getHeader(1);
+                assert.deepStrictEqual(actual, expected);
+            });
+
+            test('should return undefined header with an out of bounds index', () => {
+                const input = 'a,b,c\n1,2,3\nx,y,z';
+                const expected = undefined;
+                const actual = new Parser().parse(input).getHeader(10);
+                assert.deepStrictEqual(actual, expected);
+            });
+
         });
 
     });


### PR DESCRIPTION
This pull request adds a new `DocumentSymbolProvider` for the CSV language. The `DocumentSymbolProvider` provides symbol information for CSV files, allowing users to navigate and explore the structure of CSV documents.

Fixes #4