### PR TITLE
Create HoverProvider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,10 @@
 // Library
 import * as vscode from 'vscode';
-import { DocumentSemanticTokensProvider, DocumentSymbolProvider } from './providers';
+import {
+	DocumentSemanticTokensProvider,
+	DocumentSymbolProvider,
+	HoverProvider,
+} from './providers';
 
 /** This method is called when your extension is activated */
 export function activate(context: vscode.ExtensionContext) {
@@ -12,6 +16,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register the document symbol provider for the CSV language to provide symbol information
 	DocumentSymbolProvider.initialize(context);
+
+	// Register the hover provider for the CSV language to provide hover information
+	HoverProvider.initialize(context);
 
 }
 

--- a/src/library/VSCSV.ts
+++ b/src/library/VSCSV.ts
@@ -38,7 +38,7 @@ export class VSCSV extends _Parser<Cell> {
 /**
  * A cell in a CSV file. Holds information about the cell
  */
-type Cell = {
+export type Cell = {
     /** The value of the cell */
     value: string;
     /** The line number of the cell */

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -79,7 +79,7 @@ export class HoverProvider implements vscode.HoverProvider {
         header = header ? ` (${header})` : '';
         const string = [
             line,
-            `Row: ${row + 1}, Column: ${column + 1}${header}`
+            `Row: \`${row + 1}\`, Column: \`${column + 1}\`${header}`
         ];
         return string.map(s => new vscode.MarkdownString(s));
     }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,5 +1,6 @@
 // Library
 import * as vscode from 'vscode';
+import { VSCSV } from '../library';
 
 // --------------
 // HOVER PROVIDER
@@ -38,8 +39,31 @@ export class HoverProvider implements vscode.HoverProvider {
     // INSTANCE
     // --------
 
+    /** The CSV parser */
+    private parser = new VSCSV();
+
     provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
-        throw new Error('Method not implemented.');
+
+        // Parse the document
+        const csv = this.parser.parse(document.getText());
+
+        // Iterate over the cells in the CSV document...
+        for (const r in csv.data) {
+            for (const c in csv.data[r]) {
+                // ...get the cell...
+                const cell = csv.getCell(+r, +c);
+                if (!cell) { continue; } // Skip empty cells
+
+                // ...and return a hover if the cell contains the hovered position
+                if (cell.range.contains(position)) {
+                    return new vscode.Hover(`Row: ${+r + 1}, Column: ${+c + 1}`);
+                }
+            }
+        }
+
+        // Return null if no hover is provided
+        return null;
+
     }
 
 }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,0 +1,45 @@
+// Library
+import * as vscode from 'vscode';
+
+// --------------
+// HOVER PROVIDER
+// --------------
+
+export class HoverProvider implements vscode.HoverProvider {
+
+    // STATIC
+    // ------
+
+    /** The document selector for the CSV language */
+    private static selector: vscode.DocumentSelector = { language: 'csv' };
+
+    /** The disposable used to unregister this provider, when needed */
+    private static disposable: vscode.Disposable;
+
+    /**
+     * Initialize the hover provider for the CSV language to provide hover information.
+     * @param context The vscode extension context (see {@linkcode vscode.ExtensionContext})
+     * @see {@link vscode.languages.registerHoverProvider}
+     * @see {@link vscode.HoverProvider}
+     */
+    public static initialize(context: vscode.ExtensionContext) {
+        this.disposable?.dispose(); // Dispose of any existing provider
+        // Register the hover provider for the CSV language to provide hover information
+        this.disposable = vscode.languages.registerHoverProvider(this.selector, new HoverProvider());
+        // Register the disposable to dispose of the provider when the extension is deactivated
+        context.subscriptions.push(this.disposable);
+    }
+
+    /** Dispose of the hover provider. @see {@link vscode.Disposable} */
+    public static dispose() {
+        this.disposable?.dispose();
+    }
+
+    // INSTANCE
+    // --------
+
+    provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+        throw new Error('Method not implemented.');
+    }
+
+}

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -56,7 +56,12 @@ export class HoverProvider implements vscode.HoverProvider {
 
                 // ...and return a hover if the cell contains the hovered position
                 if (cell.range.contains(position)) {
-                    return new vscode.Hover(this.determineHoverContents(+r, +c));
+                    return new vscode.Hover(this.determineHoverContents(
+                        document.lineAt(+r).text,
+                        +r,
+                        +c,
+                        csv.getHeader(+c)?.value
+                    ));
                 }
             }
         }
@@ -70,9 +75,11 @@ export class HoverProvider implements vscode.HoverProvider {
      * Determines the hover contents for the given row and column
      * @returns A markdown string or array of markdown strings to display in the hover
      */
-    determineHoverContents(row: number, column: number): vscode.MarkdownString | (vscode.MarkdownString)[] {
+    determineHoverContents(line: string, row: number, column: number, header: string = ""): vscode.MarkdownString | (vscode.MarkdownString)[] {
+        header = header ? ` (${header})` : '';
         const string = [
-            `Row: ${row + 1}, Column: ${column + 1}`
+            line,
+            `Row: ${row + 1}, Column: ${column + 1}${header}`
         ];
         return string.map(s => new vscode.MarkdownString(s));
     }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,6 +1,6 @@
 // Library
 import * as vscode from 'vscode';
-import { VSCSV } from '../library';
+import { Cell, VSCSV } from '../library';
 
 // --------------
 // HOVER PROVIDER
@@ -56,7 +56,7 @@ export class HoverProvider implements vscode.HoverProvider {
 
                 // ...and return a hover if the cell contains the hovered position
                 if (cell.range.contains(position)) {
-                    return new vscode.Hover(`Row: ${+r + 1}, Column: ${+c + 1}`);
+                    return new vscode.Hover(this.determineHoverContents(+r, +c));
                 }
             }
         }
@@ -64,6 +64,17 @@ export class HoverProvider implements vscode.HoverProvider {
         // Return null if no hover is provided
         return null;
 
+    }
+
+    /**
+     * Determines the hover contents for the given row and column
+     * @returns A markdown string or array of markdown strings to display in the hover
+     */
+    determineHoverContents(row: number, column: number): vscode.MarkdownString | (vscode.MarkdownString)[] {
+        const string = [
+            `Row: ${row + 1}, Column: ${column + 1}`
+        ];
+        return string.map(s => new vscode.MarkdownString(s));
     }
 
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,3 +4,4 @@
 
 export * from './highlight';
 export * from './symbols';
+export * from './hover';


### PR DESCRIPTION
This pull request adds a HoverProvider for the CSV language. The HoverProvider allows users to hover over cells in a CSV file and view additional information about the cell, such as the row and column number. This feature enhances the user experience by providing more context and information while working with CSV files.