### PR TITLE
Add DiagnosticsProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable/disable hover information in csv/tsv files"
+        },
+        "vscsv.enableDiagnostics": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable diagnostics for csv/tsv files"
         }
       }
     },

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -17,6 +17,7 @@ export class Configuration {
         enableSyntaxHighlighting: true,
         enableDocumentSymbols: true,
         enableHoverInformation: true,
+        enableDiagnostics: true,
     };
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,12 @@
 // Library
 import * as vscode from 'vscode';
 import { Configuration } from './configuration';
-import { DocumentSymbols, HoverInformation, SyntaxHighlighting } from './initializers';
+import {
+	Diagnostics,
+	DocumentSymbols,
+	HoverInformation,
+	SyntaxHighlighting
+} from './initializers';
 
 /** This method is called when your extension is activated */
 export function activate(context: vscode.ExtensionContext) {
@@ -19,6 +24,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register the hover provider for the CSV language to provide hover information
 	HoverInformation.initialize(context);
+
+	// Register the diagnostics provider for the CSV language to provide diagnostics
+	Diagnostics.initialize(context);
 
 }
 

--- a/src/initializers/diagnostics.ts
+++ b/src/initializers/diagnostics.ts
@@ -1,0 +1,15 @@
+// Library
+import * as vscode from 'vscode';
+import { DiagnosticsProvider } from '../providers';
+
+// -----------
+// DIAGNOSTICS
+// -----------
+
+/** Initialize the diagnostics provider */
+export function initialize(context: vscode.ExtensionContext) {
+
+    // Register the diagnostics provider to provide diagnostics
+    DiagnosticsProvider.initialize(context);
+
+}

--- a/src/initializers/diagnostics.ts
+++ b/src/initializers/diagnostics.ts
@@ -1,6 +1,7 @@
 // Library
 import * as vscode from 'vscode';
 import { DiagnosticsProvider } from '../providers';
+import { Configuration } from '../configuration';
 
 // -----------
 // DIAGNOSTICS
@@ -10,6 +11,17 @@ import { DiagnosticsProvider } from '../providers';
 export function initialize(context: vscode.ExtensionContext) {
 
     // Register the diagnostics provider to provide diagnostics
-    DiagnosticsProvider.initialize(context);
+    if (Configuration.get('enableDiagnostics')) {
+        DiagnosticsProvider.initialize(context);
+    }
+
+    // Register the configuration listener for `enableDiagnostics` setting
+    Configuration.registerListener('enableDiagnostics', (value) => {
+        if (value) {
+            DiagnosticsProvider.initialize(context);
+        } else {
+            DiagnosticsProvider.dispose();
+        }
+    });
 
 }

--- a/src/initializers/index.ts
+++ b/src/initializers/index.ts
@@ -5,3 +5,4 @@
 export * as SyntaxHighlighting from './syntaxHighlighting';
 export * as DocumentSymbols from './documentSymbols';
 export * as HoverInformation from './hoverInformation';
+export * as Diagnostics from './diagnostics';

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1,0 +1,128 @@
+// Library
+import * as vscode from 'vscode';
+import { VSCSV } from '../library';
+
+// -----------
+// DIAGNOSTICS
+// -----------
+
+/** A diagnostics provider for the CSV language to provide diagnostics. */
+export class DiagnosticsProvider {
+
+    /** The name of the language for which this provider provides diagnostics */
+    private static name = 'csv';
+
+    /**
+     * This collection of diagnostics, once registered with vscode, will be displayed in the Problems panel
+     * @see {@link vscode.DiagnosticCollection}
+     */
+    protected static diagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection(this.name);
+
+    /**
+     * Initializes the {@linkcode diagnostics} collection and subscribes to events.
+     * This happens after the object has been created using the constructor, so that
+     * all the properties have been properly initialized before they are used.
+     * @param context The extension context ({@linkcode vscode.ExtensionContext})
+     */
+    static initialize(context: vscode.ExtensionContext) {
+
+        // Provide diagnostics for the active document
+        if (vscode.window.activeTextEditor) {
+            this.provideDiagnostics(vscode.window.activeTextEditor.document);
+        }
+
+        // Subscribe to events
+        this.subscribeToEvents(context);
+
+    }
+
+    /** Dispose off the diagnostics provider */
+    static dispose() {
+        this.diagnostics.dispose();
+    }
+
+    /**
+     * Determines whether {@link diagnostics} are allowed for the given {@link vscode.TextDocument | text document}
+     * @param document The {@link vscode.TextDocument | text document} to check ({@linkcode vscode.TextDocument})
+     * @returns `true` if {@link diagnostics} are allowed for the given {@link vscode.TextDocument | text document}, `false` otherwise
+     */
+    private static shouldProvideDiagnostics(document: vscode.TextDocument): boolean {
+        return document && document.languageId === this.name;
+    }
+
+    /**
+     * Provides {@link diagnostics} for the given {@link vscode.TextDocument | text document}
+     * @param document The {@link vscode.TextDocument | text document} for which to provide {@link diagnostics} ({@linkcode vscode.TextDocument})
+     */
+    private static provideDiagnostics(document: vscode.TextDocument) {
+        if (document && this.shouldProvideDiagnostics(document)) {
+            const diagnostics = this.getDiagnostics(document);
+            this.diagnostics.set(document.uri, diagnostics);
+        }
+    }
+
+    /** The parser used to parse the CSV document */
+    private static parser = new VSCSV();
+
+    /**
+     * Get the collection of diagnostics for the given document
+     * @param document The document for which to provide diagnostics
+     * @returns The collection of diagnostics for the given document
+     */
+    private static getDiagnostics(document: vscode.TextDocument): vscode.Diagnostic[] {
+        const diagnostics: vscode.Diagnostic[] = [];
+
+        const csv = this.parser.parse(document.getText());
+
+        const colLength = csv.headers.length;
+
+        for (const r in csv.data) {
+            const row = csv.data[r];
+            if (row.length !== colLength) {
+                const range = new vscode.Range(+r, 0, +r, Number.MAX_VALUE);
+                const diagnostic = new vscode.Diagnostic(
+                    range,
+                    `Expected ${colLength} columns, found ${row.length}`,
+                    vscode.DiagnosticSeverity.Warning
+                );
+                diagnostics.push(diagnostic);
+            }
+        }
+
+        return diagnostics;
+    }
+
+
+    /**
+     * Subscribe to events that will trigger diagnostics
+     * @param context The extension context ({@linkcode vscode.ExtensionContext})
+     */
+    private static subscribeToEvents(context: vscode.ExtensionContext) {
+        context.subscriptions.push(
+
+            // Update diagnostics when the active document changes
+            vscode.window.onDidChangeActiveTextEditor(editor => {
+                if (editor) {
+                    this.provideDiagnostics(editor.document);
+                }
+            }),
+
+            // Update diagnostics when the document is changed
+            // vscode.workspace.onDidChangeTextDocument(event => {
+            //     this.provideDiagnostics(event.document);
+            // }),
+
+            // Update diagnostics when the document is saved
+            vscode.workspace.onDidSaveTextDocument(document => {
+                this.provideDiagnostics(document);
+            }),
+
+            // Clear diagnostics when the document is closed
+            vscode.workspace.onDidCloseTextDocument(document => {
+                this.diagnostics.delete(document.uri);
+            }),
+
+        );
+    }
+
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,3 +5,4 @@
 export * from './highlight';
 export * from './symbols';
 export * from './hover';
+export * from './diagnostics';


### PR DESCRIPTION
This pull request adds a `DiagnosticsProvider` for the CSV language. The `DiagnosticsProvider` is responsible for providing diagnostics for CSV documents, such as checking for the correct number of columns in each row. This PR includes the creation and initialization of the `DiagnosticsProvider`, as well as the necessary changes to the initializers and providers files.

Fixes #9