### PR TITLE
Centralize document parsing with a cache

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 // Library
 import * as vscode from 'vscode';
+import { DocumentCache } from './library';
 
 // Configuration
 import { Configuration } from './configuration';
@@ -22,6 +23,9 @@ import {
 
 /** This method is called when your extension is activated */
 export function activate(context: vscode.ExtensionContext) {
+
+	// Initialize the document cache
+	DocumentCache.initialize(context);
 
 	// Register the configuration manager
 	Configuration.initialize(context);

--- a/src/library/DocumentCache.ts
+++ b/src/library/DocumentCache.ts
@@ -1,0 +1,93 @@
+// Library
+import * as vscode from 'vscode';
+import { VSCSV, Data, Cell } from './Parser';
+import { language } from './helpers';
+
+/**
+ * A cache for parsed document data.
+ */
+export class DocumentCache {
+
+    private static cache = new Map<string, Data<Cell>>();
+    private static parser = new VSCSV();
+
+    /**
+     * Gets the parsed data for a document from the cache.
+     * If the document is not in the cache, it will be parsed and added.
+     * @param document The document to get the parsed data for.
+     * @returns The parsed data for the document, or undefined if the language is not supported.
+     */
+    public static get(document: vscode.TextDocument): Data<Cell> | undefined {
+        if (!language.isSupported(document.languageId)) {
+            return undefined;
+        }
+
+        const uri = document.uri.toString();
+        // Return from cache if it exists
+        if (this.cache.has(uri)) {
+            return this.cache.get(uri);
+        }
+
+        // Otherwise, update the cache and return the new data
+        return this.update(document);
+    }
+
+    /**
+     * Parses a document and updates its entry in the cache.
+     * @param document The document to parse and update in the cache.
+     * @returns The newly parsed data.
+     */
+    public static update(document: vscode.TextDocument): Data<Cell> | undefined {
+        if (!language.isSupported(document.languageId)) {
+            return undefined;
+        }
+
+        // Determine the delimiter and parse the document
+        this.parser.determineDelimiter(document);
+        const parsedData = this.parser.parse(document.getText());
+
+        // Set the cache
+        const uri = document.uri.toString();
+        this.cache.set(uri, parsedData);
+
+        return parsedData;
+    }
+
+    /**
+     * Deletes a document from the cache.
+     * @param document The document to delete from the cache.
+     */
+    public static delete(document: vscode.TextDocument): void {
+        this.cache.delete(document.uri.toString());
+    }
+
+    /**
+     * Initializes the document cache and subscribes to workspace events.
+     * @param context The extension context.
+     */
+    public static initialize(context: vscode.ExtensionContext): void {
+        // Update cache for currently active editor, if any
+        if (vscode.window.activeTextEditor) {
+            this.update(vscode.window.activeTextEditor.document);
+        }
+
+        context.subscriptions.push(
+            // Update cache when a document is changed
+            vscode.workspace.onDidChangeTextDocument(e => {
+                this.update(e.document);
+            }),
+
+            // Delete from cache when a document is closed
+            vscode.workspace.onDidCloseTextDocument(doc => {
+                this.delete(doc);
+            }),
+
+            // Update cache for active editor when it changes
+            vscode.window.onDidChangeActiveTextEditor(editor => {
+                if (editor) {
+                    this.get(editor.document); // Use get instead of update to avoid unnecessary parsing
+                }
+            })
+        );
+    }
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -5,3 +5,4 @@
 export * from './Parser';
 export * from './helpers';
 export * from './extension';
+export * from './DocumentCache';

--- a/src/providers/classes/DocumentSymbolProvider.ts
+++ b/src/providers/classes/DocumentSymbolProvider.ts
@@ -1,6 +1,6 @@
 // Library
 import * as vscode from 'vscode';
-import { VSCSV } from '../../library';
+import { DocumentCache } from '../../library';
 
 // ------------------------
 // DOCUMENT SYMBOL PROVIDER
@@ -48,16 +48,10 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
     // INSTANCE
     // --------
 
-    /** The CSV parser */
-    private parser = new VSCSV();
-
     public provideDocumentSymbols(
         document: vscode.TextDocument,
         token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
-
-        // Determine the delimiter to use based on the language ID of the document
-        this.parser.determineDelimiter(document);
 
         /**
          * This {@link vscode.DocumentSymbol | symbol} will be the parent of all other symbols in the document
@@ -67,8 +61,9 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
          */
         const documentSymbol = this.createDocumentSymbol(document);
 
-        // Parse the CSV document
-        const csv = this.parser.parse(document.getText());
+        // Get the parsed CSV document from the cache
+        const csv = DocumentCache.get(document);
+        if (!csv) { return []; }
 
         // Iterate over the rows in the CSV document...
         csv.forEach((row, r) => {

--- a/src/providers/classes/HoverProvider.ts
+++ b/src/providers/classes/HoverProvider.ts
@@ -1,6 +1,6 @@
 // Library
 import * as vscode from 'vscode';
-import { VSCSV } from '../../library';
+import { DocumentCache } from '../../library';
 
 // --------------
 // HOVER PROVIDER
@@ -42,16 +42,11 @@ export class HoverProvider implements vscode.HoverProvider {
     // INSTANCE
     // --------
 
-    /** The CSV parser */
-    private parser = new VSCSV();
-
     provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
 
-        // Determine the delimiter to use based on the language ID of the document
-        this.parser.determineDelimiter(document);
-
-        // Parse the document
-        const csv = this.parser.parse(document.getText());
+        // Get the parsed document from the cache
+        const csv = DocumentCache.get(document);
+        if (!csv) { return null; }
 
         // Iterate over the cells in the CSV document...
         for (const r in csv) {


### PR DESCRIPTION
The `HoverProvider`, `StatusBarProvider`, and `DocumentSymbolProvider` now utilize a centralized document cache to avoid re-parsing the entire document on every request. This change significantly improves performance by reducing CPU usage and UI lag, especially with large files. The cache is populated when a document is opened and updated only when the document's text content changes.

Fixes #40